### PR TITLE
fix detectron2 model weights

### DIFF
--- a/demo.py
+++ b/demo.py
@@ -55,7 +55,7 @@ def main():
     cfg = detectron2.config.get_cfg()
     cfg.merge_from_file(model_zoo.get_config_file("COCO-Detection/faster_rcnn_X_101_32x8d_FPN_3x.yaml"))
     cfg.MODEL.ROI_HEADS.SCORE_THRESH_TEST = 0.5 
-    cfg.MODEL.WEIGHTS = "https://dl.fbaipublicfiles.com/detectron2/ViTDet/COCO/cascade_mask_rcnn_vitdet_h/f328730692/model_final_f05665.pkl"
+    cfg.MODEL.WEIGHTS = "https://dl.fbaipublicfiles.com/detectron2/COCO-Detection/faster_rcnn_X_101_32x8d_FPN_3x/139173657/model_final_68b088.pkl" 
     detector = detectron2.engine.DefaultPredictor(cfg)
 
     img_paths = sorted([img for end in args.file_type for img in Path(args.img_folder).glob(end)])


### PR DESCRIPTION
Thanks for the great work!

I noticed that the original Detectron2 weights specified in demo.py seem to be incorrect. When I run the code I encounter the following errors

<details>
<summary>Click to expand error log</summary>
`The checkpoint state_dict contains keys that are not used by the model:
  backbone.simfp_2.4.weight
  backbone.simfp_2.4.norm.{bias, weight}
  backbone.simfp_2.5.weight
  backbone.simfp_2.5.norm.{bias, weight}
  backbone.simfp_3.1.weight
  backbone.simfp_3.1.norm.{bias, weight}
  backbone.simfp_3.2.weight
  backbone.simfp_3.2.norm.{bias, weight}
  backbone.simfp_4.0.weight
  backbone.simfp_4.0.norm.{bias, weight}
  backbone.simfp_4.1.weight
  backbone.simfp_4.1.norm.{bias, weight}
  backbone.simfp_5.1.weight
  backbone.simfp_5.1.norm.{bias, weight}
  backbone.simfp_5.2.weight
  backbone.simfp_5.2.norm.{bias, weight}
  backbone.net.pos_embed
  backbone.net.patch_embed.proj.{bias, weight}
  backbone.net.blocks.0.norm1.{bias, weight}
  backbone.net.blocks.0.attn.{rel_pos_h, rel_pos_w}
  backbone.net.blocks.0.attn.qkv.{bias, weight}
  backbone.net.blocks.0.attn.proj.{bias, weight}
  backbone.net.blocks.0.norm2.{bias, weight}
  backbone.net.blocks.0.mlp.fc1.{bias, weight}
  backbone.net.blocks.0.mlp.fc2.{bias, weight}
  backbone.net.blocks.1.norm1.{bias, weight}
  backbone.net.blocks.1.attn.{rel_pos_h, rel_pos_w}
  backbone.net.blocks.1.attn.qkv.{bias, weight}
  backbone.net.blocks.1.attn.proj.{bias, weight}
  backbone.net.blocks.1.norm2.{bias, weight}
  backbone.net.blocks.1.mlp.fc1.{bias, weight}
  backbone.net.blocks.1.mlp.fc2.{bias, weight}
  backbone.net.blocks.2.norm1.{bias, weight}
  backbone.net.blocks.2.attn.{rel_pos_h, rel_pos_w}
  backbone.net.blocks.2.attn.qkv.{bias, weight}
  backbone.net.blocks.2.attn.proj.{bias, weight}
  backbone.net.blocks.2.norm2.{bias, weight}
  backbone.net.blocks.2.mlp.fc1.{bias, weight}
  backbone.net.blocks.2.mlp.fc2.{bias, weight}
  backbone.net.blocks.3.norm1.{bias, weight}
  backbone.net.blocks.3.attn.{rel_pos_h, rel_pos_w}
  backbone.net.blocks.3.attn.qkv.{bias, weight}
  backbone.net.blocks.3.attn.proj.{bias, weight}
  backbone.net.blocks.3.norm2.{bias, weight}
  backbone.net.blocks.3.mlp.fc1.{bias, weight}
  backbone.net.blocks.3.mlp.fc2.{bias, weight}
  backbone.net.blocks.4.norm1.{bias, weight}
  backbone.net.blocks.4.attn.{rel_pos_h, rel_pos_w}
  backbone.net.blocks.4.attn.qkv.{bias, weight}
  backbone.net.blocks.4.attn.proj.{bias, weight}
  backbone.net.blocks.4.norm2.{bias, weight}
  backbone.net.blocks.4.mlp.fc1.{bias, weight}
  backbone.net.blocks.4.mlp.fc2.{bias, weight}
  backbone.net.blocks.5.norm1.{bias, weight}
  backbone.net.blocks.5.attn.{rel_pos_h, rel_pos_w}
  backbone.net.blocks.5.attn.qkv.{bias, weight}
  backbone.net.blocks.5.attn.proj.{bias, weight}
  backbone.net.blocks.5.norm2.{bias, weight}
  backbone.net.blocks.5.mlp.fc1.{bias, weight}
  backbone.net.blocks.5.mlp.fc2.{bias, weight}
  backbone.net.blocks.6.norm1.{bias, weight}
  backbone.net.blocks.6.attn.{rel_pos_h, rel_pos_w}
  backbone.net.blocks.6.attn.qkv.{bias, weight}
  backbone.net.blocks.6.attn.proj.{bias, weight}
  backbone.net.blocks.6.norm2.{bias, weight}
  backbone.net.blocks.6.mlp.fc1.{bias, weight}
  backbone.net.blocks.6.mlp.fc2.{bias, weight}
  backbone.net.blocks.7.norm1.{bias, weight}
  backbone.net.blocks.7.attn.{rel_pos_h, rel_pos_w}
  backbone.net.blocks.7.attn.qkv.{bias, weight}
  backbone.net.blocks.7.attn.proj.{bias, weight}
  backbone.net.blocks.7.norm2.{bias, weight}
  backbone.net.blocks.7.mlp.fc1.{bias, weight}
  backbone.net.blocks.7.mlp.fc2.{bias, weight}
  backbone.net.blocks.8.norm1.{bias, weight}
  backbone.net.blocks.8.attn.{rel_pos_h, rel_pos_w}
  backbone.net.blocks.8.attn.qkv.{bias, weight}
  backbone.net.blocks.8.attn.proj.{bias, weight}
  backbone.net.blocks.8.norm2.{bias, weight}
  backbone.net.blocks.8.mlp.fc1.{bias, weight}
  backbone.net.blocks.8.mlp.fc2.{bias, weight}
  backbone.net.blocks.9.norm1.{bias, weight}
  backbone.net.blocks.9.attn.{rel_pos_h, rel_pos_w}
  backbone.net.blocks.9.attn.qkv.{bias, weight}
  backbone.net.blocks.9.attn.proj.{bias, weight}
  backbone.net.blocks.9.norm2.{bias, weight}
  backbone.net.blocks.9.mlp.fc1.{bias, weight}
  backbone.net.blocks.9.mlp.fc2.{bias, weight}
  backbone.net.blocks.10.norm1.{bias, weight}
  backbone.net.blocks.10.attn.{rel_pos_h, rel_pos_w}
  backbone.net.blocks.10.attn.qkv.{bias, weight}
  backbone.net.blocks.10.attn.proj.{bias, weight}
  backbone.net.blocks.10.norm2.{bias, weight}
  backbone.net.blocks.10.mlp.fc1.{bias, weight}
  backbone.net.blocks.10.mlp.fc2.{bias, weight}
  backbone.net.blocks.11.norm1.{bias, weight}
  backbone.net.blocks.11.attn.{rel_pos_h, rel_pos_w}
  backbone.net.blocks.11.attn.qkv.{bias, weight}
  backbone.net.blocks.11.attn.proj.{bias, weight}
  backbone.net.blocks.11.norm2.{bias, weight}
  backbone.net.blocks.11.mlp.fc1.{bias, weight}
  backbone.net.blocks.11.mlp.fc2.{bias, weight}
  backbone.net.blocks.12.norm1.{bias, weight}
  backbone.net.blocks.12.attn.{rel_pos_h, rel_pos_w}
  backbone.net.blocks.12.attn.qkv.{bias, weight}
  backbone.net.blocks.12.attn.proj.{bias, weight}
  backbone.net.blocks.12.norm2.{bias, weight}
  backbone.net.blocks.12.mlp.fc1.{bias, weight}
  backbone.net.blocks.12.mlp.fc2.{bias, weight}
  backbone.net.blocks.13.norm1.{bias, weight}
  backbone.net.blocks.13.attn.{rel_pos_h, rel_pos_w}
  backbone.net.blocks.13.attn.qkv.{bias, weight}
  backbone.net.blocks.13.attn.proj.{bias, weight}
  backbone.net.blocks.13.norm2.{bias, weight}
  backbone.net.blocks.13.mlp.fc1.{bias, weight}
  backbone.net.blocks.13.mlp.fc2.{bias, weight}
  backbone.net.blocks.14.norm1.{bias, weight}
  backbone.net.blocks.14.attn.{rel_pos_h, rel_pos_w}
  backbone.net.blocks.14.attn.qkv.{bias, weight}
  backbone.net.blocks.14.attn.proj.{bias, weight}
  backbone.net.blocks.14.norm2.{bias, weight}
  backbone.net.blocks.14.mlp.fc1.{bias, weight}
  backbone.net.blocks.14.mlp.fc2.{bias, weight}
  backbone.net.blocks.15.norm1.{bias, weight}
  backbone.net.blocks.15.attn.{rel_pos_h, rel_pos_w}
  backbone.net.blocks.15.attn.qkv.{bias, weight}
  backbone.net.blocks.15.attn.proj.{bias, weight}
  backbone.net.blocks.15.norm2.{bias, weight}
  backbone.net.blocks.15.mlp.fc1.{bias, weight}
  backbone.net.blocks.15.mlp.fc2.{bias, weight}
  backbone.net.blocks.16.norm1.{bias, weight}
  backbone.net.blocks.16.attn.{rel_pos_h, rel_pos_w}
  backbone.net.blocks.16.attn.qkv.{bias, weight}
  backbone.net.blocks.16.attn.proj.{bias, weight}
  backbone.net.blocks.16.norm2.{bias, weight}
  backbone.net.blocks.16.mlp.fc1.{bias, weight}
  backbone.net.blocks.16.mlp.fc2.{bias, weight}
  backbone.net.blocks.17.norm1.{bias, weight}
  backbone.net.blocks.17.attn.{rel_pos_h, rel_pos_w}
  backbone.net.blocks.17.attn.qkv.{bias, weight}
  backbone.net.blocks.17.attn.proj.{bias, weight}
  backbone.net.blocks.17.norm2.{bias, weight}
  backbone.net.blocks.17.mlp.fc1.{bias, weight}
  backbone.net.blocks.17.mlp.fc2.{bias, weight}
  backbone.net.blocks.18.norm1.{bias, weight}
  backbone.net.blocks.18.attn.{rel_pos_h, rel_pos_w}
  backbone.net.blocks.18.attn.qkv.{bias, weight}
  backbone.net.blocks.18.attn.proj.{bias, weight}
  backbone.net.blocks.18.norm2.{bias, weight}
  backbone.net.blocks.18.mlp.fc1.{bias, weight}
  backbone.net.blocks.18.mlp.fc2.{bias, weight}
  backbone.net.blocks.19.norm1.{bias, weight}
  backbone.net.blocks.19.attn.{rel_pos_h, rel_pos_w}
  backbone.net.blocks.19.attn.qkv.{bias, weight}
  backbone.net.blocks.19.attn.proj.{bias, weight}
  backbone.net.blocks.19.norm2.{bias, weight}
  backbone.net.blocks.19.mlp.fc1.{bias, weight}
  backbone.net.blocks.19.mlp.fc2.{bias, weight}
  backbone.net.blocks.20.norm1.{bias, weight}
  backbone.net.blocks.20.attn.{rel_pos_h, rel_pos_w}
  backbone.net.blocks.20.attn.qkv.{bias, weight}
  backbone.net.blocks.20.attn.proj.{bias, weight}
  backbone.net.blocks.20.norm2.{bias, weight}
  backbone.net.blocks.20.mlp.fc1.{bias, weight}
  backbone.net.blocks.20.mlp.fc2.{bias, weight}
  backbone.net.blocks.21.norm1.{bias, weight}
  backbone.net.blocks.21.attn.{rel_pos_h, rel_pos_w}
  backbone.net.blocks.21.attn.qkv.{bias, weight}
  backbone.net.blocks.21.attn.proj.{bias, weight}
  backbone.net.blocks.21.norm2.{bias, weight}
  backbone.net.blocks.21.mlp.fc1.{bias, weight}
  backbone.net.blocks.21.mlp.fc2.{bias, weight}
  backbone.net.blocks.22.norm1.{bias, weight}
  backbone.net.blocks.22.attn.{rel_pos_h, rel_pos_w}
  backbone.net.blocks.22.attn.qkv.{bias, weight}
  backbone.net.blocks.22.attn.proj.{bias, weight}
  backbone.net.blocks.22.norm2.{bias, weight}
  backbone.net.blocks.22.mlp.fc1.{bias, weight}
  backbone.net.blocks.22.mlp.fc2.{bias, weight}
  backbone.net.blocks.23.norm1.{bias, weight}
  backbone.net.blocks.23.attn.{rel_pos_h, rel_pos_w}
  backbone.net.blocks.23.attn.qkv.{bias, weight}
  backbone.net.blocks.23.attn.proj.{bias, weight}
  backbone.net.blocks.23.norm2.{bias, weight}
  backbone.net.blocks.23.mlp.fc1.{bias, weight}
  backbone.net.blocks.23.mlp.fc2.{bias, weight}
  backbone.net.blocks.24.norm1.{bias, weight}
  backbone.net.blocks.24.attn.{rel_pos_h, rel_pos_w}
  backbone.net.blocks.24.attn.qkv.{bias, weight}
  backbone.net.blocks.24.attn.proj.{bias, weight}
  backbone.net.blocks.24.norm2.{bias, weight}
  backbone.net.blocks.24.mlp.fc1.{bias, weight}
  backbone.net.blocks.24.mlp.fc2.{bias, weight}
  backbone.net.blocks.25.norm1.{bias, weight}
  backbone.net.blocks.25.attn.{rel_pos_h, rel_pos_w}
  backbone.net.blocks.25.attn.qkv.{bias, weight}
  backbone.net.blocks.25.attn.proj.{bias, weight}
  backbone.net.blocks.25.norm2.{bias, weight}
  backbone.net.blocks.25.mlp.fc1.{bias, weight}
  backbone.net.blocks.25.mlp.fc2.{bias, weight}
  backbone.net.blocks.26.norm1.{bias, weight}
  backbone.net.blocks.26.attn.{rel_pos_h, rel_pos_w}
  backbone.net.blocks.26.attn.qkv.{bias, weight}
  backbone.net.blocks.26.attn.proj.{bias, weight}
  backbone.net.blocks.26.norm2.{bias, weight}
  backbone.net.blocks.26.mlp.fc1.{bias, weight}
  backbone.net.blocks.26.mlp.fc2.{bias, weight}
  backbone.net.blocks.27.norm1.{bias, weight}
  backbone.net.blocks.27.attn.{rel_pos_h, rel_pos_w}
  backbone.net.blocks.27.attn.qkv.{bias, weight}
  backbone.net.blocks.27.attn.proj.{bias, weight}
  backbone.net.blocks.27.norm2.{bias, weight}
  backbone.net.blocks.27.mlp.fc1.{bias, weight}
  backbone.net.blocks.27.mlp.fc2.{bias, weight}
  backbone.net.blocks.28.norm1.{bias, weight}
  backbone.net.blocks.28.attn.{rel_pos_h, rel_pos_w}
  backbone.net.blocks.28.attn.qkv.{bias, weight}
  backbone.net.blocks.28.attn.proj.{bias, weight}
  backbone.net.blocks.28.norm2.{bias, weight}
  backbone.net.blocks.28.mlp.fc1.{bias, weight}
  backbone.net.blocks.28.mlp.fc2.{bias, weight}
  backbone.net.blocks.29.norm1.{bias, weight}
  backbone.net.blocks.29.attn.{rel_pos_h, rel_pos_w}
  backbone.net.blocks.29.attn.qkv.{bias, weight}
  backbone.net.blocks.29.attn.proj.{bias, weight}
  backbone.net.blocks.29.norm2.{bias, weight}
  backbone.net.blocks.29.mlp.fc1.{bias, weight}
  backbone.net.blocks.29.mlp.fc2.{bias, weight}
  backbone.net.blocks.30.norm1.{bias, weight}
  backbone.net.blocks.30.attn.{rel_pos_h, rel_pos_w}
  backbone.net.blocks.30.attn.qkv.{bias, weight}
  backbone.net.blocks.30.attn.proj.{bias, weight}
  backbone.net.blocks.30.norm2.{bias, weight}
  backbone.net.blocks.30.mlp.fc1.{bias, weight}
  backbone.net.blocks.30.mlp.fc2.{bias, weight}
  backbone.net.blocks.31.norm1.{bias, weight}
  backbone.net.blocks.31.attn.{rel_pos_h, rel_pos_w}
  backbone.net.blocks.31.attn.qkv.{bias, weight}
  backbone.net.blocks.31.attn.proj.{bias, weight}
  backbone.net.blocks.31.norm2.{bias, weight}
  backbone.net.blocks.31.mlp.fc1.{bias, weight}
  backbone.net.blocks.31.mlp.fc2.{bias, weight}
  backbone.simfp_2.0.{bias, weight}
  backbone.simfp_2.1.{bias, weight}
  backbone.simfp_2.3.{bias, weight}
  backbone.simfp_3.0.{bias, weight}
  proposal_generator.rpn_head.conv.conv0.{bias, weight}
  proposal_generator.rpn_head.conv.conv1.{bias, weight}
  roi_heads.mask_head.mask_fcn1.weight
  roi_heads.mask_head.mask_fcn1.norm.{bias, weight}
  roi_heads.mask_head.mask_fcn2.weight
  roi_heads.mask_head.mask_fcn2.norm.{bias, weight}
  roi_heads.mask_head.mask_fcn3.weight
  roi_heads.mask_head.mask_fcn3.norm.{bias, weight}
  roi_heads.mask_head.mask_fcn4.weight
  roi_heads.mask_head.mask_fcn4.norm.{bias, weight}
  roi_heads.mask_head.deconv.{bias, weight}
  roi_heads.mask_head.predictor.{bias, weight}
  roi_heads.box_head.0.conv1.weight
  roi_heads.box_head.0.conv1.norm.{bias, weight}
  roi_heads.box_head.0.conv2.weight
  roi_heads.box_head.0.conv2.norm.{bias, weight}
  roi_heads.box_head.0.conv3.weight
  roi_heads.box_head.0.conv3.norm.{bias, weight}
  roi_heads.box_head.0.conv4.weight
  roi_heads.box_head.0.conv4.norm.{bias, weight}
  roi_heads.box_head.0.fc1.{bias, weight}
  roi_heads.box_head.1.conv1.weight
  roi_heads.box_head.1.conv1.norm.{bias, weight}
  roi_heads.box_head.1.conv2.weight
  roi_heads.box_head.1.conv2.norm.{bias, weight}
  roi_heads.box_head.1.conv3.weight
  roi_heads.box_head.1.conv3.norm.{bias, weight}
  roi_heads.box_head.1.conv4.weight
  roi_heads.box_head.1.conv4.norm.{bias, weight}
  roi_heads.box_head.1.fc1.{bias, weight}
  roi_heads.box_head.2.conv1.weight
  roi_heads.box_head.2.conv1.norm.{bias, weight}
  roi_heads.box_head.2.conv2.weight
  roi_heads.box_head.2.conv2.norm.{bias, weight}
  roi_heads.box_head.2.conv3.weight
  roi_heads.box_head.2.conv3.norm.{bias, weight}
  roi_heads.box_head.2.conv4.weight
  roi_heads.box_head.2.conv4.norm.{bias, weight}
  roi_heads.box_head.2.fc1.{bias, weight}
  roi_heads.box_predictor.0.cls_score.{bias, weight}
  roi_heads.box_predictor.0.bbox_pred.{bias, weight}
  roi_heads.box_predictor.1.cls_score.{bias, weight}
  roi_heads.box_predictor.1.bbox_pred.{bias, weight}
  roi_heads.box_predictor.2.cls_score.{bias, weight}
  roi_heads.box_predictor.2.bbox_pred.{bias, weight}`
</details>

I resolved the issue by replacing the model weights with the correct ones from the official Detectron2 model zoo:
https://github.com/facebookresearch/detectron2/blob/main/MODEL_ZOO.md
Please double-check that this is the intended model for detection. Let me know if a different architecture was meant to be used.